### PR TITLE
Fix: [create-collabo-app] Migrate/Add Email and Password Authentication (only) - for `ts-esm-async-await` template only

### DIFF
--- a/ts-esm-async-await/package-lock.json
+++ b/ts-esm-async-await/package-lock.json
@@ -9,18 +9,22 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "esm": "^3.2.25",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
+        "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.0.5",
         "morgan": "^1.10.0"
       },
       "devDependencies": {
+        "@types/bcrypt": "^5.0.2",
         "@types/body-parser": "^1.19.2",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/morgan": "^1.9.4",
         "@types/node": "^18.16.1",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
@@ -168,6 +172,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
@@ -236,6 +273,15 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -299,6 +345,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -573,8 +628,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -618,6 +672,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -638,7 +703,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -671,6 +735,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -700,8 +781,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -718,6 +798,19 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/bcrypt": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "node-addon-api": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -771,7 +864,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -796,6 +888,11 @@
       "engines": {
         "node": ">=14.20.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -884,6 +981,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -902,11 +1007,23 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1010,6 +1127,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1025,6 +1147,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -1071,10 +1201,23 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -1591,11 +1734,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1617,6 +1781,25 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1653,7 +1836,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1775,6 +1957,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1799,6 +1986,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -1865,7 +2064,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1915,6 +2113,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2000,6 +2206,46 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -2057,6 +2303,16 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
@@ -2068,6 +2324,26 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
@@ -2081,6 +2357,11 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
     "node_modules/lodash.unionwith": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.unionwith/-/lodash.unionwith-4.6.0.tgz",
@@ -2091,12 +2372,33 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -2203,12 +2505,53 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mongodb": {
@@ -2369,6 +2712,49 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "2.0.22",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
@@ -2472,6 +2858,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2511,7 +2908,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2611,7 +3007,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2742,6 +3137,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2777,7 +3185,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -2839,7 +3246,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2904,6 +3310,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -2972,8 +3383,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/simple-update-notifier": {
       "version": "1.1.0",
@@ -3049,11 +3459,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3092,6 +3522,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/text-table": {
@@ -3284,6 +3730,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -3341,17 +3792,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/ts-esm-async-await/package-lock.json
+++ b/ts-esm-async-await/package-lock.json
@@ -14,7 +14,6 @@
         "dotenv": "^16.0.3",
         "esm": "^3.2.25",
         "express": "^4.18.2",
-        "express-async-errors": "^3.1.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.0.5",
         "morgan": "^1.10.0"
@@ -1550,14 +1549,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express-async-errors": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
-      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
-      "peerDependencies": {
-        "express": "^4.16.2"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/ts-esm-async-await/package.json
+++ b/ts-esm-async-await/package.json
@@ -17,7 +17,6 @@
     "dotenv": "^16.0.3",
     "esm": "^3.2.25",
     "express": "^4.18.2",
-    "express-async-errors": "^3.1.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.0.5",
     "morgan": "^1.10.0"

--- a/ts-esm-async-await/package.json
+++ b/ts-esm-async-await/package.json
@@ -12,18 +12,22 @@
   "author": "Obiagba Mary",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "esm": "^3.2.25",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.0.5",
     "morgan": "^1.10.0"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.2",
     "@types/body-parser": "^1.19.2",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/morgan": "^1.9.4",
     "@types/node": "^18.16.1",
     "@typescript-eslint/eslint-plugin": "^5.59.1",

--- a/ts-esm-async-await/src/api/controllers/demo.controller.ts
+++ b/ts-esm-async-await/src/api/controllers/demo.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import {
   getDemoItemsService,
   createDemoItemService,
@@ -14,105 +14,134 @@ const item = `${routeName}-item`;
 
 let response: { [key: string]: unknown } = {};
 
-export const getDemoItemsController = async (req: Request, res: Response) => {
-  const docs = await getDemoItemsService();
-  response = {
-    count: docs.length,
-    items: docs.map(doc => {
-      return {
+export const getDemoItemsController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const docs = await getDemoItemsService();
+    response = {
+      count: docs.length,
+      items: docs.map(doc => {
+        return {
+          _id: doc._id,
+          name: doc.name,
+          age: doc.age,
+          request: {
+            type: 'GET',
+            url: `http://localhost:3000/${routeName}/${doc._id}`
+          }
+        }
+      })
+    };
+    success(`GET request successful!`);
+    return res.status(200).json(response);
+    
+  } catch (err) {
+    next(err);
+  }
+}
+
+export const createDemoItemController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const doc = await createDemoItemService(req.body);
+    response = {
+      message: `${item} created successfully!`,
+      newItem: {
         _id: doc._id,
         name: doc.name,
         age: doc.age,
         request: {
           type: 'GET',
-          url: `http://localhost:3000/${routeName}/${doc._id}`
-        }
-      }
-    })
-  };
-  success(`GET request successful!`);
-  return res.status(200).json(response);
+          url: `http://localhost:3000/${routeName}/${doc._id}`,
+        },
+      },
+    }
+    success(`${item} CREATED successfully!`);
+    return res.status(201).json(response);
+    
+  } catch (err) {
+    next(err);
+  }
 }
 
-export const createDemoItemController = async (req: Request, res: Response) => {
-  const doc = await createDemoItemService(req.body);
-  response = {
-    message: `${item} created successfully!`,
-    newItem: {
+export const getOneDemoItemController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const doc = await getOneDemoItemService(req.params.demoId);
+    response = {
       _id: doc._id,
       name: doc.name,
       age: doc.age,
       request: {
         type: 'GET',
-        url: `http://localhost:3000/${routeName}/${doc._id}`,
+        description: `Url link to all ${item}s`,
+        url: `http://localhost:3000/${routeName}/`,
       },
-    },
+    }
+    success(`GET request successful!`);
+    return res.status(200).json(response);
+    
+  } catch (err) {
+    next(err);
   }
-  success(`${item} CREATED successfully!`);
-  return res.status(201).json(response);
 }
 
-export const getOneDemoItemController = async (req: Request, res: Response) => {
-  const doc = await getOneDemoItemService(req.params.demoId);
-  response = {
-    _id: doc._id,
-    name: doc.name,
-    age: doc.age,
-    request: {
-      type: 'GET',
-      description: `Url link to all ${item}s`,
-      url: `http://localhost:3000/${routeName}/`,
-    },
-  }
-  success(`GET request successful!`);
-  return res.status(200).json(response);
-
-}
-
-export const deleteDemoItemController = async (req: Request, res: Response) => {
-  await deleteDemoItemService(req.params.demoId);
-  response = {
-    message: `${item} deleted successfully!`,
-    request: {
-      type: 'POST',
-      description: 'Url link to make post request to',
-      url: `http://localhost:3000/${item}/`,
-      body: {
-        name: 'String',
-        age: 'Number',
+export const deleteDemoItemController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await deleteDemoItemService(req.params.demoId);
+    response = {
+      message: `${item} deleted successfully!`,
+      request: {
+        type: 'POST',
+        description: 'Url link to make post request to',
+        url: `http://localhost:3000/${item}/`,
+        body: {
+          name: 'String',
+          age: 'Number',
+        },
       },
-    },
+    }
+    success(`${item} DELETED successfully!`);
+    return res.status(200).json(response);
+    
+  } catch (err) {
+    next(err);
   }
-  success(`${item} DELETED successfully!`);
-  return res.status(200).json(response);
 };
 
-export const updateOneDemoItemPropertyValueController = async (req: Request, res: Response) => {
-  const id: string = req.params.demoId;
-  await updateOneDemoItemPropertyValueService(id, req.body);
-  response = {
-    message: 'Patch request successful!',
-    request: {
-      type: 'GET',
-      description: `Url link to updated ${item}`,
-      url: `http://localhost:3000/${routeName}/${id}`,
-    },
-  };
-  success(`PATCH request for ID ${id} successful!`);
-  return res.status(200).json(response);
+export const updateOneDemoItemPropertyValueController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id: string = req.params.demoId;
+    await updateOneDemoItemPropertyValueService(id, req.body);
+    response = {
+      message: 'Patch request successful!',
+      request: {
+        type: 'GET',
+        description: `Url link to updated ${item}`,
+        url: `http://localhost:3000/${routeName}/${id}`,
+      },
+    };
+    success(`PATCH request for ID ${id} successful!`);
+    return res.status(200).json(response);
+    
+  } catch (err) {
+    next(err);
+  }
 };
 
-export const updateDemoItemPropertyValuesController = async (req: Request, res: Response) => {
-  const id: string = req.params.id;
-  await updateDemoItemPropertyValuesService(id, req.body);
-  response = {
-    message: `Put request successful!`,
-    request: {
-      type: 'GET',
-      description: `Url link to updated ${item}`,
-      url: `http://localhost:3000/${routeName}/${id}`,
-    },
-  };
-  success(`PUT request for ID ${id} successful!`);
-  return res.status(200).json(response);
+export const updateDemoItemPropertyValuesController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id: string = req.params.id;
+    await updateDemoItemPropertyValuesService(id, req.body);
+    response = {
+      message: `Put request successful!`,
+      request: {
+        type: 'GET',
+        description: `Url link to updated ${item}`,
+        url: `http://localhost:3000/${routeName}/${id}`,
+      },
+    };
+    success(`PUT request for ID ${id} successful!`);
+    return res.status(200).json(response);
+    
+  } catch (err) {
+    next(err);
+  }
 };

--- a/ts-esm-async-await/src/api/controllers/user.auth.controller.ts
+++ b/ts-esm-async-await/src/api/controllers/user.auth.controller.ts
@@ -1,0 +1,55 @@
+import { Request, Response } from 'express';
+import {
+  signUpOneUserService,
+  loginOneUserService,
+} from '../services/user.auth.service';
+import { success } from '../../lib/helpers';
+import jwt from 'jsonwebtoken';
+
+// const routeName = 'user';
+// const item = `${routeName}-item`;
+
+let response: { [key: string]: unknown } = {};
+
+//---------------------- AUTHENTICATION (SIGNUP AND LOGIN) -------------------------------//
+export const signUpOneUserController = async (req: Request, res: Response) => {
+  const user = await signUpOneUserService(req.body);
+  const token = jwt.sign(
+    {_id: user._id, username: user.username, role: user.role},
+    process.env.JWT_SECRET,
+    {expiresIn: process.env.JWT_LIFETIME});
+  response = {
+    success: true,
+    data: {
+      user: {
+        _id: user._id,
+        username: user.username,
+        email: user.email,
+        role: user.role,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      },
+      token: token
+    },
+    message: `SUCCESS: User registration successfull`,
+  };
+  success(`SUCCESS: User registration successfull`);
+  return res.status(201).json(response);
+}
+
+
+export const loginOneUserController = async (req: Request, res: Response) => {
+  const user = await loginOneUserService(req.body);
+  const token = jwt.sign(
+    {_id: user._id, username: user.username, role: user.role},
+    process.env.JWT_SECRET,
+    {expiresIn: process.env.JWT_LIFETIME});
+  response = {
+    success: true,
+    data: { token: token },
+    message: `SUCCESS: User successfully logged in`,
+  };
+  success(`SUCCESS: User successfully logged in`);
+  return res.status(201).json(response);
+}
+//------------------------------------------------------------------------------------------//

--- a/ts-esm-async-await/src/api/controllers/user.auth.controller.ts
+++ b/ts-esm-async-await/src/api/controllers/user.auth.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import {
   signUpOneUserService,
   loginOneUserService,
@@ -12,44 +12,55 @@ import jwt from 'jsonwebtoken';
 let response: { [key: string]: unknown } = {};
 
 //---------------------- AUTHENTICATION (SIGNUP AND LOGIN) -------------------------------//
-export const signUpOneUserController = async (req: Request, res: Response) => {
-  const user = await signUpOneUserService(req.body);
-  const token = jwt.sign(
-    {_id: user._id, username: user.username, role: user.role},
-    process.env.JWT_SECRET,
-    {expiresIn: process.env.JWT_LIFETIME});
-  response = {
-    success: true,
-    data: {
-      user: {
-        _id: user._id,
-        username: user.username,
-        email: user.email,
-        role: user.role,
-        createdAt: user.createdAt,
-        updatedAt: user.updatedAt,
+export const signUpOneUserController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = await signUpOneUserService(req.body);
+    const token = jwt.sign(
+      {_id: user._id, username: user.username, role: user.role},
+      process.env.JWT_SECRET,
+      {expiresIn: process.env.JWT_LIFETIME});
+    response = {
+      success: true,
+      data: {
+        user: {
+          _id: user._id,
+          username: user.username,
+          email: user.email,
+          role: user.role,
+          createdAt: user.createdAt,
+          updatedAt: user.updatedAt,
+        },
+        token: token
       },
-      token: token
-    },
-    message: `SUCCESS: User registration successfull`,
-  };
-  success(`SUCCESS: User registration successfull`);
-  return res.status(201).json(response);
+      message: `SUCCESS: User registration successfull`,
+    };
+    success(`SUCCESS: User registration successfull`);
+    return res.status(201).json(response);
+
+  } catch (err) {
+    next(err);
+  }
 }
 
 
-export const loginOneUserController = async (req: Request, res: Response) => {
-  const user = await loginOneUserService(req.body);
-  const token = jwt.sign(
-    {_id: user._id, username: user.username, role: user.role},
-    process.env.JWT_SECRET,
-    {expiresIn: process.env.JWT_LIFETIME});
-  response = {
-    success: true,
-    data: { token: token },
-    message: `SUCCESS: User successfully logged in`,
-  };
-  success(`SUCCESS: User successfully logged in`);
-  return res.status(201).json(response);
+export const loginOneUserController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = await loginOneUserService(req.body);
+    const token = jwt.sign(
+      {_id: user._id, username: user.username, role: user.role},
+      process.env.JWT_SECRET,
+      { expiresIn: process.env.JWT_LIFETIME }
+    );
+    response = {
+      success: true,
+      data: { token: token },
+      message: `SUCCESS: User successfully logged in`,
+    };
+    success(`SUCCESS: User successfully logged in`);
+    return res.status(201).json(response);
+
+  } catch (err) {
+    next(err);
+  }
 }
 //------------------------------------------------------------------------------------------//

--- a/ts-esm-async-await/src/api/controllers/user.controller.ts
+++ b/ts-esm-async-await/src/api/controllers/user.controller.ts
@@ -1,0 +1,109 @@
+import { Request, Response } from 'express';
+import {
+  getAllUsersService,
+  getOneUserService,
+  deleteOneUserService,
+  updateOneUserPropertyValueService,
+  updateUserPropertyValuesService,
+  deleteAllUserService,
+  
+} from '../services/user.service';
+import { success } from '../../lib/helpers';
+import { ReqUser } from '../../types';
+
+// const routeName = 'user';
+// const item = `${routeName}-item`;
+
+let response: { [key: string]: unknown } = {};
+
+export const getAllUsersController = async (req: Request, res: Response) => {
+  const docs = await getAllUsersService();
+  response = {
+    success: true,
+    data: {
+      count: docs.length,
+      users: docs.map(doc => {
+        return {
+          _id: doc._id,
+          username: doc.username,
+          email: doc.email,
+          role: doc.role,
+          createdAt: doc.createdAt,
+          updatedAt: doc.updatedAt,
+        }
+      })
+    },
+    message: `SUCCESS: All users succesfully retrieved`,
+  };
+  success(`SUCCESS: All users succesfully retrieved`);
+  return res.status(200).json(response);
+}
+
+export const getOneUserController = async (req: ReqUser, res: Response) => {
+  const doc = await getOneUserService(req.user._id);
+  const response = {
+    success: true,
+    data: {
+      user: {
+        _id: doc._id,
+        username: doc.username,
+        email: doc.email,
+        role: doc.role,
+        createdAt: doc.createdAt,
+        updatedAt: doc.updatedAt,
+      }
+    },
+    message: `SUCCESS: User succesfully retrieved`,
+  };
+  success(`SUCCESS: User succesfully retrieved`);
+  return res.status(200).json(response);
+}
+
+export const deleteOneUserController = async (req: ReqUser, res: Response) => {
+  await deleteOneUserService(req.user._id);
+  response = {
+    success: true,
+    data: {},
+    message: `SUCCESS: User successfully deleted`,
+  };
+  success(`SUCCESS: User successfully deleted`);
+  return res.status(201).json(response);
+};
+
+export const updateOneUserPropertyValueController = async (req: ReqUser, res: Response) => {
+  const id: string = req.user._id;
+  await updateOneUserPropertyValueService(req.user._id, req.body);
+  response = {
+    success: true,
+    data: {},
+    message: `PATCH update request for ID ${id} successful!`,
+  };
+  success(`PATCH update request for ID ${id} successful!`);
+  return res.status(200).json(response);
+}
+
+export const updateUserPropertyValuesController = async (req: ReqUser, res: Response) => {
+  const id: string = req.user._id;
+  await updateUserPropertyValuesService(req.user._id, req.body);
+  response = {
+    success: true,
+    data: {},
+    message: `PUT update request for ID ${id} successful!`,
+  };
+  success(`PUT update request for ID ${id} successful!`);
+  return res.status(200).json(response);
+}
+
+
+//------------------------------------------------------------------------------------------//
+export const deleteAllUserController = async (req: Request, res: Response) => {
+  const doc = await deleteAllUserService();
+  const response = {
+    success: true,
+    data: {},
+    message: `${doc.deletedCount} user(s) deleted successfully!`,
+  };
+  success(response.message);
+  return res.status(201).json(response);
+};
+//------------------------------------------------------------------------------------------//

--- a/ts-esm-async-await/src/api/controllers/user.controller.ts
+++ b/ts-esm-async-await/src/api/controllers/user.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import {
   getAllUsersService,
   getOneUserService,
@@ -16,14 +16,41 @@ import { ReqUser } from '../../types';
 
 let response: { [key: string]: unknown } = {};
 
-export const getAllUsersController = async (req: Request, res: Response) => {
-  const docs = await getAllUsersService();
-  response = {
-    success: true,
-    data: {
-      count: docs.length,
-      users: docs.map(doc => {
-        return {
+export const getAllUsersController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const docs = await getAllUsersService();
+    response = {
+      success: true,
+      data: {
+        count: docs.length,
+        users: docs.map(doc => {
+          return {
+            _id: doc._id,
+            username: doc.username,
+            email: doc.email,
+            role: doc.role,
+            createdAt: doc.createdAt,
+            updatedAt: doc.updatedAt,
+          }
+        })
+      },
+      message: `SUCCESS: All users succesfully retrieved`,
+    };
+    success(`SUCCESS: All users succesfully retrieved`);
+    return res.status(200).json(response);
+
+  } catch (err) {
+    next(err);
+  }
+}
+
+export const getOneUserController = async (req: ReqUser, res: Response, next: NextFunction) => {
+  try {
+    const doc = await getOneUserService(req.user._id);
+    const response = {
+      success: true,
+      data: {
+        user: {
           _id: doc._id,
           username: doc.username,
           email: doc.email,
@@ -31,79 +58,82 @@ export const getAllUsersController = async (req: Request, res: Response) => {
           createdAt: doc.createdAt,
           updatedAt: doc.updatedAt,
         }
-      })
-    },
-    message: `SUCCESS: All users succesfully retrieved`,
-  };
-  success(`SUCCESS: All users succesfully retrieved`);
-  return res.status(200).json(response);
+      },
+      message: `SUCCESS: User succesfully retrieved`,
+    };
+    success(`SUCCESS: User succesfully retrieved`);
+    return res.status(200).json(response);
+
+  } catch (err) {
+    next(err);
+  }
 }
 
-export const getOneUserController = async (req: ReqUser, res: Response) => {
-  const doc = await getOneUserService(req.user._id);
-  const response = {
-    success: true,
-    data: {
-      user: {
-        _id: doc._id,
-        username: doc.username,
-        email: doc.email,
-        role: doc.role,
-        createdAt: doc.createdAt,
-        updatedAt: doc.updatedAt,
-      }
-    },
-    message: `SUCCESS: User succesfully retrieved`,
-  };
-  success(`SUCCESS: User succesfully retrieved`);
-  return res.status(200).json(response);
-}
+export const deleteOneUserController = async (req: ReqUser, res: Response, next: NextFunction) => {
+  try {
+    await deleteOneUserService(req.user._id);
+    response = {
+      success: true,
+      data: {},
+      message: `SUCCESS: User successfully deleted`,
+    };
+    success(`SUCCESS: User successfully deleted`);
+    return res.status(201).json(response);
 
-export const deleteOneUserController = async (req: ReqUser, res: Response) => {
-  await deleteOneUserService(req.user._id);
-  response = {
-    success: true,
-    data: {},
-    message: `SUCCESS: User successfully deleted`,
-  };
-  success(`SUCCESS: User successfully deleted`);
-  return res.status(201).json(response);
+  } catch (err) {
+    next(err);
+  }
 };
 
-export const updateOneUserPropertyValueController = async (req: ReqUser, res: Response) => {
-  const id: string = req.user._id;
-  await updateOneUserPropertyValueService(req.user._id, req.body);
-  response = {
-    success: true,
-    data: {},
-    message: `PATCH update request for ID ${id} successful!`,
-  };
-  success(`PATCH update request for ID ${id} successful!`);
-  return res.status(200).json(response);
+export const updateOneUserPropertyValueController = async (req: ReqUser, res: Response, next: NextFunction) => {
+  try {
+    const id: string = req.user._id;
+    await updateOneUserPropertyValueService(req.user._id, req.body);
+    response = {
+      success: true,
+      data: {},
+      message: `PATCH update request for ID ${id} successful!`,
+    };
+    success(`PATCH update request for ID ${id} successful!`);
+    return res.status(200).json(response);
+    
+  } catch (err) {
+    next(err);
+  }
 }
 
-export const updateUserPropertyValuesController = async (req: ReqUser, res: Response) => {
-  const id: string = req.user._id;
-  await updateUserPropertyValuesService(req.user._id, req.body);
-  response = {
-    success: true,
-    data: {},
-    message: `PUT update request for ID ${id} successful!`,
-  };
-  success(`PUT update request for ID ${id} successful!`);
-  return res.status(200).json(response);
+export const updateUserPropertyValuesController = async (req: ReqUser, res: Response, next: NextFunction) => {
+  try {
+    const id: string = req.user._id;
+    await updateUserPropertyValuesService(req.user._id, req.body);
+    response = {
+      success: true,
+      data: {},
+      message: `PUT update request for ID ${id} successful!`,
+    };
+    success(`PUT update request for ID ${id} successful!`);
+    return res.status(200).json(response);
+    
+  } catch (err) {
+    next(err);
+  }
 }
 
 
 //------------------------------------------------------------------------------------------//
-export const deleteAllUserController = async (req: Request, res: Response) => {
-  const doc = await deleteAllUserService();
-  const response = {
-    success: true,
-    data: {},
-    message: `${doc.deletedCount} user(s) deleted successfully!`,
-  };
-  success(response.message);
-  return res.status(201).json(response);
+export const deleteAllUserController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const doc = await deleteAllUserService();
+    const response = {
+      success: true,
+      data: {},
+      message: `${doc.deletedCount} user(s) deleted successfully!`,
+    };
+    success(response.message);
+    return res.status(201).json(response);
+    
+  } catch (err) {
+    next(err);
+  }
 };
 //------------------------------------------------------------------------------------------//

--- a/ts-esm-async-await/src/api/middleware/auth.middleware.ts
+++ b/ts-esm-async-await/src/api/middleware/auth.middleware.ts
@@ -1,0 +1,48 @@
+import { Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { UserRole } from '../models/user.model';
+import { unAuthorizedErr } from '../../lib/errors/Errors';
+import { Payload, ReqUser } from '../../types';
+
+
+// -----------------------------------------------------------------------------------------------------------//
+// https://www.sailpoint.com/identity-library/difference-between-authentication-and-authorization/
+// AUTHENTICATION is the process of verifying who someone is (This is done during SIGNUP, LOGIN, and JWT)
+// AUTHORIZATION is the process of verifying what specific applications, files, and data a user 
+//               has access to (Usually by ROLES)
+// -----------------------------------------------------------------------------------------------------------//
+
+
+export const authenticateUserWithJWT = async (req: ReqUser, res: Response, next: NextFunction) => {
+  // check header if it starts with bearer
+  const reqAuthorizationHeader = req.headers.authorization;
+
+  if (!reqAuthorizationHeader || !reqAuthorizationHeader.startsWith("Bearer ")) {
+    unAuthorizedErr("User could not be verified because authorization header bearer not found");
+  }
+
+  const userToken = reqAuthorizationHeader.split(" ")[1];
+
+  const decoded = jwt.verify(userToken, `${process.env.JWT_SECRET}`);
+  const payload = decoded as Payload;
+  const { _id, username, role } = payload;
+
+  req.user = { _id: _id, username: username, role: role };
+
+  return next();
+}
+
+
+export const authorizeByUserRoles = (allowedRoles: UserRole[]) => {
+  return (req: ReqUser, res: Response, next: NextFunction) => {
+    const { role } = req.user;
+
+    const roleIsVerified = allowedRoles.includes(role);
+
+    if (roleIsVerified) {
+      return next();
+    }
+
+    unAuthorizedErr(`only [${allowedRoles}] have access to this route`);
+  }
+}

--- a/ts-esm-async-await/src/api/models/user.model.ts
+++ b/ts-esm-async-await/src/api/models/user.model.ts
@@ -1,0 +1,48 @@
+import mongoose from 'mongoose';
+import bcrypt from "bcrypt";
+
+export enum UserRole {
+  Admin = 'admin',
+  User = 'user',
+}
+
+export interface UserDocument extends mongoose.Document {
+  _id?: string;
+  username: string;
+  email: string;
+  password: string;
+  role: UserRole;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const collectionName = 'user';
+
+const UserSchema = new mongoose.Schema({
+  username: {type: String, required: true, unique: true},
+  email: {type: String, required: true, unique: true,
+    match: [
+      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+      "please provide valid email",
+    ]},
+  password: { type: String, required: true },
+  role: { type: String, required: true, default: UserRole.User}
+},
+{
+  timestamps: true,
+});
+
+UserSchema.pre('save', async function(next){
+  // Only run this function if password was moddified (not on other update functions)
+  if (!this.isModified("password")){
+    return next();
+  }
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
+
+  return next();
+})
+
+const UserModel = mongoose.model<UserDocument>(collectionName, UserSchema, collectionName); //declare collection name a second time to prevent mongoose from pluralizing or adding 's' to the collection name
+
+export { UserModel };

--- a/ts-esm-async-await/src/api/routes/user.auth.route.ts
+++ b/ts-esm-async-await/src/api/routes/user.auth.route.ts
@@ -1,0 +1,12 @@
+import express, { IRouter } from 'express';
+import {
+  signUpOneUserController,
+  loginOneUserController,
+} from '../controllers/user.auth.controller';
+
+const router: IRouter = express.Router();
+
+router.post('/signup', signUpOneUserController);
+router.post('/login', loginOneUserController);
+
+export { router };

--- a/ts-esm-async-await/src/api/routes/user.route.ts
+++ b/ts-esm-async-await/src/api/routes/user.route.ts
@@ -18,7 +18,7 @@ router.get('/get-properties', authenticateUserWithJWT, authorizeByUserRoles([Use
 router.patch('/update-any-property', authenticateUserWithJWT, authorizeByUserRoles([UserRole.User]), updateOneUserPropertyValueController);
 router.put('/update-properties', authenticateUserWithJWT, authorizeByUserRoles([UserRole.User]), updateUserPropertyValuesController);
 
-router.delete('/delete', authenticateUserWithJWT, authorizeByUserRoles([UserRole.User]), deleteOneUserController);
+router.delete('/delete', authenticateUserWithJWT, authorizeByUserRoles([UserRole.Admin]), deleteOneUserController);
 
 //-----------------------------------------------------//
 router.delete('/', deleteAllUserController);

--- a/ts-esm-async-await/src/api/routes/user.route.ts
+++ b/ts-esm-async-await/src/api/routes/user.route.ts
@@ -1,0 +1,27 @@
+import express, { IRouter } from 'express';
+import {
+  getAllUsersController,
+  getOneUserController,
+  deleteOneUserController,
+  updateOneUserPropertyValueController,
+  updateUserPropertyValuesController,
+  deleteAllUserController,
+} from '../controllers/user.controller';
+import { UserRole } from '../models/user.model';
+import { authenticateUserWithJWT, authorizeByUserRoles } from '../middleware/auth.middleware';
+
+const router: IRouter = express.Router();
+
+router.get('/', getAllUsersController);
+router.get('/get-properties', authenticateUserWithJWT, authorizeByUserRoles([UserRole.User]), getOneUserController);
+
+router.patch('/update-any-property', authenticateUserWithJWT, authorizeByUserRoles([UserRole.User]), updateOneUserPropertyValueController);
+router.put('/update-properties', authenticateUserWithJWT, authorizeByUserRoles([UserRole.User]), updateUserPropertyValuesController);
+
+router.delete('/delete', authenticateUserWithJWT, authorizeByUserRoles([UserRole.User]), deleteOneUserController);
+
+//-----------------------------------------------------//
+router.delete('/', deleteAllUserController);
+//-----------------------------------------------------//
+
+export { router };

--- a/ts-esm-async-await/src/api/services/user.auth.service.ts
+++ b/ts-esm-async-await/src/api/services/user.auth.service.ts
@@ -1,0 +1,37 @@
+import { badRequestErr } from '../../lib/errors/Errors';
+import { UserDocument, UserModel as User } from '../models/user.model';
+import bcrypt from 'bcrypt';
+
+type LoginDocument = Pick<UserDocument, "email" | "password">
+
+
+//---------------------- AUTHENTICATION (SIGNUP AND LOGIN) -------------------------------//
+export const signUpOneUserService = async (requestBody: UserDocument): Promise<UserDocument> => {
+  const user = new User({
+    username: requestBody.username,
+    email: requestBody.email,
+    password: requestBody.password,
+  });
+  const save = await user.save();
+  return save;
+};
+
+export const loginOneUserService = async (requestBody: LoginDocument) => {
+  const {email, password} = requestBody;
+  // check if email and password was provided
+  if (!email && !password){
+    badRequestErr("Please provide email and password");
+  }
+  // check if the user is registered in the database
+  const user = await User.findOne({email: email});
+  if(!user){
+    badRequestErr("invalid credentials [EMAIL]");
+  }
+  // check if correct password was provided
+  const isPasswordCorrect = await bcrypt.compare(password, user.password);
+  if(!isPasswordCorrect) {
+    badRequestErr("invalid credentials [PASSWORD]");
+  }
+  return user;
+};
+//------------------------------------------------------------------------------------------//

--- a/ts-esm-async-await/src/api/services/user.service.ts
+++ b/ts-esm-async-await/src/api/services/user.service.ts
@@ -1,0 +1,66 @@
+import { badRequestErr, notFoundErr } from '../../lib/errors/Errors';
+import { UserDocument, UserModel as User } from '../models/user.model';
+
+
+export const getAllUsersService = async () => {
+  const query = await User.find().exec();
+  return query;
+};
+
+export const getOneUserService = async (paramsId: string) => {
+  const query = await User.findById(paramsId).exec();
+  if(!query){
+    notFoundErr('No record found for provided ID');
+  }
+  return query;
+};
+
+export const deleteOneUserService = async (paramsId: string) => {
+  const query = await User.deleteOne({ _id: paramsId }).exec();
+  if (query.deletedCount < 1){
+    notFoundErr('No record found for provided ID to be deleted')
+  }
+  return query;
+}
+
+export const updateOneUserPropertyValueService = async (paramsId: string, requestBody: { propName: string, value: string }[]) => {
+  const query = await User.findById(paramsId).exec();
+  if(!query){
+    notFoundErr('No record found for provided ID');
+  }
+
+  for (const ops of requestBody) {
+    if(!(ops.propName in query)){
+      badRequestErr(`invalid property: ${ops.propName}`);
+    }
+    query[ops.propName as keyof UserDocument] = ops.value as never;
+  }
+
+  const updatedQuery = await query.save();
+  return updatedQuery;
+};
+
+export const updateUserPropertyValuesService = async (paramsId: string, requestBody: UserDocument) => {
+  const query = await User.findById(paramsId).exec();
+  if(!query){
+    notFoundErr('No record found for provided ID');
+  }
+
+  query.username = requestBody.username;
+  query.email = requestBody.email;
+  query.password = requestBody.password;
+
+  const updatedQuery = await query.save();
+  return updatedQuery;
+};
+
+
+//--------------------------------------------------------------------------------------------------//
+export const deleteAllUserService = async () => {
+  const query = await User.deleteMany().exec();
+  if (query.deletedCount < 1){
+    notFoundErr('No record found to be deleted')
+  }
+  return query;
+}
+//--------------------------------------------------------------------------------------------------//

--- a/ts-esm-async-await/src/app.ts
+++ b/ts-esm-async-await/src/app.ts
@@ -1,4 +1,3 @@
-import 'express-async-errors';
 import express, { Express, NextFunction, Request, Response } from 'express';
 import dotenv from 'dotenv';
 import morgan from 'morgan';

--- a/ts-esm-async-await/src/app.ts
+++ b/ts-esm-async-await/src/app.ts
@@ -8,6 +8,8 @@ import { CustomErrorInterface } from './lib/errors/CustomError';
 import { notFoundErr } from './lib/errors/Errors';
 import { router as appRouter } from './api/routes/app.route';
 import { router as demoRouter } from './api/routes/demo.route';
+import { router as userAuthRouter } from './api/routes/user.auth.route';
+import { router as userRouter } from './api/routes/user.route';
 
 dotenv.config();
 
@@ -23,6 +25,8 @@ app.use(cors({ origin: [`http://localhost:${process.env.CLIENT_APP_PORT}`, `${pr
 //====== Use Routers =======
 app.use('/', appRouter);
 app.use('/demo', demoRouter);
+app.use('/user/auth', userAuthRouter);
+app.use('/user', userRouter);
 //==========================
 
 

--- a/ts-esm-async-await/src/lib/errors/Errors.ts
+++ b/ts-esm-async-await/src/lib/errors/Errors.ts
@@ -13,16 +13,24 @@ class BadRequestError extends CustomError {
   }
 }
 
+class UnAuthorizedError extends CustomError {
+  constructor(message: string){
+    super(message, HttpCode.UNAUTHORIZED)
+  }
+}
+
 
 // --- Make throwing the errors cleaner in appearance for use ---
 interface ThrowError {
   notFoundErr: (message: string) => void;
   badRequestErr: (message: string) => void;
+  unAuthorizedErr: (message: string) => void;
 }
 
 const throwError: ThrowError = {
   notFoundErr: (message) => { throw new NotFoundError(message); },
   badRequestErr: (message) => { throw new BadRequestError(message); },
+  unAuthorizedErr: (message) => { throw new UnAuthorizedError(message); },
 };
 
-export const { notFoundErr, badRequestErr } = throwError;
+export const { notFoundErr, badRequestErr, unAuthorizedErr } = throwError;

--- a/ts-esm-async-await/src/types/index.ts
+++ b/ts-esm-async-await/src/types/index.ts
@@ -1,0 +1,12 @@
+import { Request } from "express";
+import { UserDocument, UserRole } from "../api/models/user.model";
+
+export interface ReqUser extends Request {
+  user?: {
+    _id?: string;
+    username?: string;
+    role?: UserRole;
+  }
+}
+
+export type Payload = Pick<UserDocument, "_id" | "username" | "role">;


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes collabo-community/contributor-issue-report#9

**General checklist**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**
- [x] basic email and password authentication has been added to the ts template only.
- [x] a new user model is added as well as services and controllers.
- [x] express-async-error module has been removed and the `try-catch-next` is now being used for error handling
- [x] only the `ts-async-await` template was touched.
- [x] The other boilerplate templates still work as before untouched.
- [x] I certify that I ran my checklist

Check the discord discussion for more info about the PR: [ts-basic-jwt-auth](https://discord.com/channels/1148391778492354741/1235607221644038254/1242051872106221589)
  
Ping @collabo-community/review-backend-api
